### PR TITLE
fix: support both "service_account_id" and "user_key"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ To run this code, you need to provide credentials from one of the authentication
 
 
 
-To set your service account credentials, set either 'SERVICE_ACCOUNT_ID' or three environment variable named 'USER_ID', 'CLIENT_ID', and 'PASSWORD'.
+To set your service account credentials, set either 'USER_KEY' or three environment variable named 'USER_ID', 'CLIENT_ID', and 'PASSWORD'.
 To set your subscription ID, simply set an environment variable named 'SUBSCRIPTION_ID' like so
 
 .. code-block::
@@ -57,7 +57,7 @@ You may pass your service account credentials (user_id, client_id, and password)
 
     from dnaStreaming.listener import Listener
     #User key authentication
-    listener = Listener(service_account_id=<YOUR USER KEY>)
+    listener = Listener(user_key=<YOUR USER KEY>)
     #or
     #UserId, ClientId, Password
 

--- a/dnaStreaming/customer_config.json
+++ b/dnaStreaming/customer_config.json
@@ -1,6 +1,7 @@
 {
 
   "user_key": "",
+  "service_account_id": "",
   "user_id": "",
   "client_id": "",
   "password": "",

--- a/dnaStreaming/customer_config.json
+++ b/dnaStreaming/customer_config.json
@@ -2,7 +2,6 @@
 
   "user_key": "",
   "service_account_id": "",
-  "user_id": "",
   "client_id": "",
   "password": "",
   "subscription_id": ""

--- a/dnaStreaming/customer_config.json
+++ b/dnaStreaming/customer_config.json
@@ -1,7 +1,7 @@
 {
 
   "user_key": "",
-  "service_account_id": "",
+  "user_id": "",
   "client_id": "",
   "password": "",
   "subscription_id": ""

--- a/dnaStreaming/listener.py
+++ b/dnaStreaming/listener.py
@@ -13,8 +13,8 @@ from dnaStreaming.services import pubsub_service, credentials_service
 class Listener(object):
     DEFAULT_UNLIMITED_MESSAGES = None
 
-    def __init__(self, service_account_id=None, user_id=None, client_id=None, password=None):
-        config = Config(service_account_id, user_id, client_id, password)
+    def __init__(self, service_account_id=None, user_key=None, user_id=None, client_id=None, password=None):
+        config = Config(service_account_id, user_key, user_id, client_id, password)
         self._initialize(config)
         self.current_subscription_index = 0
 

--- a/dnaStreaming/test/test_config.py
+++ b/dnaStreaming/test/test_config.py
@@ -77,7 +77,6 @@ class TestConfig(TestCase, PatchMixin):
         # Arrange
         os.environ[Config.ENV_VAR_USER_KEY] = '123'
         os.environ[Config.ENV_VAR_SUBSCRIPTION_ID] = 'ABC'
-        os.environ[Config.ENV_VAR_EXTRACTION_API_HOST] = 'http://hiptotherythum.com'
         os.environ[Config.ENV_VAR_USER_ID] = 'user'
         os.environ[Config.ENV_VAR_CLIENT_ID] = 'client'
         os.environ[Config.ENV_VAR_PASSWORD] = 'password'
@@ -96,6 +95,22 @@ class TestConfig(TestCase, PatchMixin):
         assert os.environ[Config.ENV_VAR_CLIENT_ID] == config.oauth2_credentials().get('client_id')
         assert os.environ[Config.ENV_VAR_PASSWORD] == config.oauth2_credentials().get('password')
 
+    def test_environment_variable_service_account_id_success(self):
+        # Arrange
+        os.environ[Config.ENV_VAR_SERVICE_ACCOUNT_ID] = 'lemme_in'
+        os.environ[Config.ENV_VAR_SUBSCRIPTION_ID] = 'ABC'
+
+        # Act
+        config = Config()
+        fileFolder = os.path.dirname(os.path.realpath(__file__))
+        config._set_customer_config_path(os.path.join(fileFolder, 'test_customer_config.json'))
+        config._initialize()
+
+        # Assert
+        assert os.environ[Config.ENV_VAR_SERVICE_ACCOUNT_ID] == config.get_user_key()
+        subscription_id = config.subscription()
+        assert subscription_id == 'ABC'
+
     def test_oauth2_creds_not_provided(self):
         # Arrange
         config = Config()
@@ -110,6 +125,15 @@ class TestConfig(TestCase, PatchMixin):
         # Arrange
         # Act
         config = Config(user_key='123')
+
+        # Assert
+        print(config.get_user_key())
+        assert config.get_user_key() == '123'
+
+    def test_service_account_id_passed_success(self):
+        # Arrange
+        # Act
+        config = Config(service_account_id='123')
 
         # Assert
         print(config.get_user_key())

--- a/dnaStreaming/test/test_customer_config.json
+++ b/dnaStreaming/test/test_customer_config.json
@@ -1,5 +1,6 @@
 {
   "user_key": "foo",
+  "service_account_id": "fu",
   "subscription_id": "bar",
   "user_id": "bill",
   "client_id": "nye",


### PR DESCRIPTION
What does this PR do?
It allows users to use either the parameter "service_account_id" or "user_key" to set their user_key for the user_key authentication flow (as either a param to the listener, an env var, or an entry in the customerConfig.json). This is to guarantee that any customers who may have been using either of these two parameter names will not have their workflow broken.

How should this be manually tested?
Run the streaming client by setting the "user_key" param to some valid user_key value. Authentication should work successfully. Rerun the client without the "user_key" param but with the "service_account_id" param set to the same value. Authentication should again work successfully for the same account.

What are the relevant tickets?
https://trello.com/c/MZU20Mtq/1377-as-a-user-of-the-streaming-clients-i-want-to-be-able-to-authenticate-with-both-serviceaccountid-and-userkey-param-names-for-the

Checklist
I added the necessary documentation, if appropriate.
I added tests to prove that my fix is effective or my feature works.
I reviewed existing Pull Requests before submitting mine.