### PR TITLE
Fix multiples errors to make docker work

### DIFF
--- a/DockerfileDemo
+++ b/DockerfileDemo
@@ -1,4 +1,4 @@
-FROM python:2.7.10
+FROM python:3.8.2-slim
 
 WORKDIR app
 

--- a/README.rst
+++ b/README.rst
@@ -229,3 +229,12 @@ Execute the following at the project root:
     -e PASSWORD=<your password> \
     -e SUBSCRIPTION_ID=<your subscription ID> \
     dj-dna-streaming-python
+
+or:
+
+.. code-block::
+
+    docker run -it \                    
+    -e USER_KEY=<your user KEY> \
+    -e SUBSCRIPTION_ID=<your subscription ID> \
+    dj-dna-streaming-python

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
 
     install_requires=[
         'googleapis-common-protos==1.6.0',
-        'google-auth==1.0.2',
+        'google-auth==1.14.0',
         'google-cloud-pubsub==0.38.0',
         'google-cloud-core==0.28.1',
         'mock==2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
 
     install_requires=[
-        'googleapis-common-protos==1.5.3',
+        'googleapis-common-protos==1.6.0',
         'google-auth==1.0.2',
         'google-cloud-pubsub==0.38.0',
         'google-cloud-core==0.28.1',


### PR DESCRIPTION
## Build stage errors

Folowing the documentation the `docker build` failed with **two errors**:

- One with googleapis-common-protos version:
```python
error: googleapis-common-protos 1.5.3 is installed but googleapis-common-protos<2.0dev,>=1.6.0 is required by set(['google-api-core'])
```
Fixed by modify `googleapis-common-protos` version from `1.5.3` to `1.6.0`

- One with google-auth version:
```python
error: google-auth 1.0.2 is installed but google-auth<2.0dev,>=1.14.0 is required by set(['google-api-core'])
```
Fixed by modify `google-auth version` from `1.0.2` to `1.14.0`

## Run stage errors

After fixing it, `docker run` failed with **one error**: 
```python
ImportError: cannot import name abstractmethod
```
Fixed by modify docker container version from `python:2.7.10` to `python:3.8.2-slim`

## Documentation

Regarding the documentation, it says : 

There are two ways to authenticate.
- Your User Key
- UserId, ClientId and Password

But for docker, user key needs `SUBSCRIPTION_ID` too. So I ve add it in documentation.

