### PR TITLE
Updated deps to be compliant with Oct 2020 pip req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 google-auth>=1.7.0
-google-cloud-pubsub>=1.0.0
-google-cloud-core>=1.0.3
-google-api-core<1.17.0,>=1.14.
+google-cloud-pubsub==1.1.0
+google-cloud-core==1.3.0
+google-api-core==1.22.0
 mock>=3.0.5
 oauth2client>=4.1.3
 requests>=2.22.0

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,8 @@ setup(
     install_requires=[
         'googleapis-common-protos>=1.6.0',
         'google-auth>=1.7.0',
-        'google-cloud-pubsub>=1.0.0',
-        'google-cloud-core>=1.0.3',
-        'google-api-core<1.17.0,>=1.14.0'
+        'google-cloud-pubsub>=1.1.0',
+        'google-cloud-core==1.3.0',
         'mock>=3.0.5',
         'oauth2client>=4.1.3',
         'requests>=2.22.0'


### PR DESCRIPTION
There's a PIP feature that is making the original dependencies install break. When running `pip install -r requirements.txt`, Google Cloud dependencies fail as PIP fails to install one of them. This is proposed to be fixed using a more recent version of Google packages in both, `requirements.txt` and `setup.py`.