### PR TITLE
HA Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,3 +123,7 @@ the subscription *and* consuming it. Instead they will just consume an already e
 ==================
 - [removed] - Fully removed legacy authentication method by password
 - [added] - Explicit argument to provide the path to the customer_config.json file to the Listener constructor (view README for more details)
+
+2.2.0 / 2024-05-21
+==================
+- [added] - Support for highly-available streams with a new method under the `Listener` class: `listen_async_ha`

--- a/dnaStreaming/demo/show_ha_stream_async.py
+++ b/dnaStreaming/demo/show_ha_stream_async.py
@@ -1,0 +1,36 @@
+import os
+from time import sleep
+from dnaStreaming.listener import Listener
+
+listener = Listener()
+quiet_demo = os.getenv('QUIET_DEMO', "false") == "true"
+max_secs = 5
+print("\n[ACTIVITY] Receiving messages (ASYNC) for {} seconds...\n[0]".format(max_secs), end='')
+
+
+def callback(message, subscription_id):
+    callback.counter += 1
+    if not quiet_demo:
+        if message['action'] != 'del':
+            print('[INFO] [MSG] [{}]: AN: {}, TITLE: {}'.format(callback.counter, message['an'], message['title']))
+        else:
+            print('[INFO] [MSG] [{}]: AN: {}, *** DELETE ***'.format(callback.counter, message['an']))
+    else:
+        if callback.counter % 10 == 0:
+            print('[{}]'.format(callback.counter), end='')
+        else:
+            print('.', end='')
+    return True
+
+
+callback.counter = 0
+listener_controller = listener.listen_async_ha(callback)
+
+# Stop receiving messages after 5 seconds
+for count in range(0, max_secs):
+    sleep(1)
+
+if listener_controller.listener_is_running():
+    listener_controller.stop_listener()
+
+print("stop receiving messages")

--- a/dnaStreaming/listener.py
+++ b/dnaStreaming/listener.py
@@ -150,8 +150,8 @@ class Listener(object):
         api_host = self.config.get_uri_context()
         user_key = self.config.get_user_key()
 
-        main_subscription_id = subscription_id
-        backup_subscription_id = subscription_id + "bak"
+        main_subscription_id = subscription_id if "-bak-" not in subscription_id else subscription_id.replace("-filtered-bak-", "-filtered-")
+        backup_subscription_id = subscription_id if "-bak-" in subscription_id else subscription_id.replace("-filtered-", "-filtered-bak-")
 
         main_subscription_path = main_pubsub_client.subscription_path(
             streaming_credentials['project_id'], main_subscription_id)

--- a/dnaStreaming/listener.py
+++ b/dnaStreaming/listener.py
@@ -148,6 +148,7 @@ class Listener(object):
             self.config)
 
         api_host = self.config.get_uri_context()
+        user_key = self.config.get_user_key()
 
         main_subscription_id = subscription_id
         backup_subscription_id = subscription_id + "bak"
@@ -160,6 +161,8 @@ class Listener(object):
         stop_event = Event()
         listener_thread = Thread(target=ha_listen, daemon=True, args=(
             api_host,
+            user_key,
+            subscription_id,
             stop_event,
             main_subscription_path,
             backup_subscription_path,

--- a/dnaStreaming/services/availability_service.py
+++ b/dnaStreaming/services/availability_service.py
@@ -6,12 +6,17 @@ from dnaStreaming import logger
 MAIN_REGION = "us-central1"
 BACKUP_REGION = "us-east5"
 
-def get_active_region(api_host):
+def get_active_region(api_host, subscription_id, user_key):
 
     try:
         ha_status_url = f"{api_host}/stream_health/get_active_region"
 
-        response = requests.get(ha_status_url)
+        headers = {
+            "subscription-id": subscription_id,
+            "user-key": user_key
+        }
+
+        response = requests.get(url=ha_status_url, headers=headers)
 
         assert response.status_code == 200, "Failed to fetch active region"
 
@@ -26,7 +31,7 @@ def get_active_region(api_host):
         return None
 
 
-def ha_listen(api_host, stop_event, main_subscription_path, backup_subscription_path, main_pubsub_client, backup_pubsub_client, callback):
+def ha_listen(api_host, user_key, subscription_id, stop_event, main_subscription_path, backup_subscription_path, main_pubsub_client, backup_pubsub_client, callback):
 
     # The listener starts reading messages from the main region by default.
 
@@ -37,7 +42,7 @@ def ha_listen(api_host, stop_event, main_subscription_path, backup_subscription_
     
     while not stop_event.is_set():
 
-        active_region = get_active_region(api_host)
+        active_region = get_active_region(api_host, subscription_id, user_key)
 
         if active_region is None or active_region not in (MAIN_REGION, BACKUP_REGION):
             logger.warning(f"Got invalid region from API: {active_region}. Listener will keep reading from region {current_region}")

--- a/dnaStreaming/services/availability_service.py
+++ b/dnaStreaming/services/availability_service.py
@@ -1,0 +1,71 @@
+import requests
+import time
+
+from dnaStreaming import logger
+
+MAIN_REGION = "us-central1"
+BACKUP_REGION = "us-east5"
+
+def get_active_region(api_host):
+    
+    ha_status_url = f"{api_host}/stream_health/get_active_region"
+    
+    response = requests.get(ha_status_url)
+    
+    if response.status_code != 200:
+        return None
+    
+    payload = response.json()
+
+    active_region = payload["data"]["active_region"]
+
+    return active_region
+
+
+def ha_listen(api_host, stop_event, main_subscription_path, backup_subscription_path, main_pubsub_client, backup_pubsub_client, callback):
+
+    # The listener starts reading messages from the main region by default.
+
+    current_region = MAIN_REGION
+
+    streaming_pull_future = main_pubsub_client.subscribe(
+            main_subscription_path, callback=callback)
+    
+    while not stop_event.is_set():
+
+        active_region = get_active_region(api_host)
+
+        if active_region is None or active_region not in (MAIN_REGION, BACKUP_REGION):
+            logger.warning(f"Got invalid region from API: {active_region}. Listener will keep reading from region {current_region}")
+            continue
+        
+        if current_region != active_region:
+
+            logger.warning(f"Regional indicent detected in {current_region}, switching to region {active_region}")
+            
+            logger.warning(f"Stopping listener in region {current_region}...")
+
+            # We stop the previous listening process
+            streaming_pull_future.cancel()
+            streaming_pull_future.result()
+
+            logger.warning(f"Stopped listener in region {current_region}")
+
+            logger.warning(f"Starting listener in region {active_region}...")
+
+            if active_region == MAIN_REGION:
+                streaming_pull_future = main_pubsub_client.subscribe(
+                    main_subscription_path, callback=callback)
+            else: # active_region == BACKUP_REGION
+                streaming_pull_future = backup_pubsub_client.subscribe(
+                    backup_subscription_path, callback=callback)
+                
+            logger.warning(f"Started listener in region {current_region}")
+
+            current_region = active_region
+        
+        # We wait 5 minutes for cooldown for next call to API
+        time.sleep(5.0 * 60)
+
+    streaming_pull_future.cancel()
+    streaming_pull_future.result()

--- a/dnaStreaming/services/availability_service.py
+++ b/dnaStreaming/services/availability_service.py
@@ -5,6 +5,7 @@ from dnaStreaming import logger
 
 MAIN_REGION = "us-central1"
 BACKUP_REGION = "us-east5"
+COOLDOWN_PERIOD = 5 * 60
 
 def get_active_region(api_host, subscription_id, user_key):
 
@@ -50,7 +51,7 @@ def ha_listen(api_host, user_key, subscription_id, stop_event, main_subscription
         
         if current_region != active_region:
 
-            logger.warning(f"Regional indicent detected in {current_region}, switching to region {active_region}")
+            logger.warning(f"Switch event detected in, switching from region {current_region} to region {active_region}")
             
             logger.warning(f"Stopping listener in region {current_region}...")
 
@@ -69,12 +70,12 @@ def ha_listen(api_host, user_key, subscription_id, stop_event, main_subscription
                 streaming_pull_future = backup_pubsub_client.subscribe(
                     backup_subscription_path, callback=callback)
                 
-            logger.warning(f"Started listener in region {current_region}")
+            logger.warning(f"Started listener in region {active_region}")
 
             current_region = active_region
         
         # We wait 5 minutes for cooldown for next call to API
-        time.sleep(5.0 * 60)
+        time.sleep(COOLDOWN_PERIOD)
 
     streaming_pull_future.cancel()
     streaming_pull_future.result()

--- a/dnaStreaming/services/availability_service.py
+++ b/dnaStreaming/services/availability_service.py
@@ -7,19 +7,23 @@ MAIN_REGION = "us-central1"
 BACKUP_REGION = "us-east5"
 
 def get_active_region(api_host):
-    
-    ha_status_url = f"{api_host}/stream_health/get_active_region"
-    
-    response = requests.get(ha_status_url)
-    
-    if response.status_code != 200:
+
+    try:
+        ha_status_url = f"{api_host}/stream_health/get_active_region"
+
+        response = requests.get(ha_status_url)
+
+        assert response.status_code == 200, "Failed to fetch active region"
+
+        payload = response.json()
+
+        active_region = payload["data"]["active_region"]
+
+        return active_region
+
+    except:
+
         return None
-    
-    payload = response.json()
-
-    active_region = payload["data"]["active_region"]
-
-    return active_region
 
 
 def ha_listen(api_host, stop_event, main_subscription_path, backup_subscription_path, main_pubsub_client, backup_pubsub_client, callback):

--- a/dnaStreaming/services/pubsub_service.py
+++ b/dnaStreaming/services/pubsub_service.py
@@ -4,10 +4,16 @@ from google.cloud.pubsub_v1 import SubscriberClient
 
 from dnaStreaming.services import authentication_service
 from dnaStreaming.services import credentials_service
+from dnaStreaming.services.availability_service import MAIN_REGION, BACKUP_REGION
 
 
-def get_client(config):
+def get_client(config, region=None):
     streaming_credentials = credentials_service.fetch_credentials(config)
     credentials = authentication_service.get_authenticated_oauth_credentials(streaming_credentials)
 
-    return SubscriberClient(credentials=credentials)
+    if region in (MAIN_REGION, BACKUP_REGION):
+        client_options = {"api_endpoint": f"{region}-pubsub.googleapis.com:443"}
+    else:
+        client_options = {"api_endpoint": "pubsub.googleapis.com:443"}
+
+    return SubscriberClient(credentials=credentials, client_options=client_options)


### PR DESCRIPTION
It integrates the Python Streams Listener with HA streams.

How to test:
- Set the following env vars:
  - SUBSCRIPTION_ID={the subscription id of an HA stream (main or backup)}
  - USER_KEY={user key of an active HA account}
- Launch the script `/dnaStreaming/demo/show_ha_stream_async.py`
- Open/close incidents with the Stream Health API to see how the listener interacts with disaster events.