### PR TITLE
Automatic publishes to PyPi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          pip install setuptools wheel build
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Upload Python Package to PyPI when a Release is Created
+name: Publish a new version to PyPI when a new release is published
 
 on:
   release:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,32 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Build package
+      run: python setup.py sdist bdist_wheel
+
+    - name: Publish package to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        pip install twine
+        twine upload dist/*

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,32 +1,30 @@
-name: Publish Python Package
+name: Upload Python Package to PyPI when a Release is Created
 
 on:
   release:
     types: [published]
 
 jobs:
-  publish:
+  pypi-publish:
+    name: Publish release to PyPI
     runs-on: ubuntu-latest
-
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dnaStreaming
+    permissions:
+      id-token: write
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.8'
-
-    - name: Install dependencies
-      run: pip install -r requirements.txt
-
-    - name: Build package
-      run: python setup.py sdist bdist_wheel
-
-    - name: Publish package to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        pip install twine
-        twine upload dist/*
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+      - name: Build package
+        run: |
+          python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-VERSION = "2.2.1.dev1"
+VERSION = "2.2.1"
 RELEASE_TAG = f"release-{VERSION}"
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-VERSION = "2.2.1-test"
+VERSION = "2.2.1.dev1"
 RELEASE_TAG = f"release-{VERSION}"
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-VERSION = "2.2.1"
+VERSION = "2.2.1-test"
 RELEASE_TAG = f"release-{VERSION}"
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37
+envlist = py38
 
 [testenv]
 commands = py.test


### PR DESCRIPTION
It adds a GitHub workflow to publish new versions of the dnaStreaming package to PyPi on new GitHub releases.

### Notes:

1. The workflow will trigger with new Github published releases.
2. Merging or pushing to master will not trigger the action.
3. We still need to manually edit the setup.py file to update the semver of the release and dependencies.
4. We can monitor the status of the publish on the Actions tab of the repo.
5. It takes less than a minute to run

### Automatic release demo:

* Release [2.2.1.dev1](https://pypi.org/manage/project/dnaStreaming/release/2.2.1.dev1/) on PyPi