### PR TITLE
Log folder is included as a parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,15 @@ To set your subscription ID, simply set an environment variable named 'SUBSCRIPT
     export SUBSCRIPTION_ID="ABC1234567889"
 
 
+To set your log folder path, simply set this folder variable named 'LOG_PATH' like so
+
+.. code-block::
+
+    export LOG_PATH="yourLogPath"
+
+
+
+
 The code above is the command line expression for setting this environment variable on Mac OSX. Other operating systems might have a slightly different techniques for setting environment variables on the command line.
 
 2. Using the configuration file.

--- a/README.rst
+++ b/README.rst
@@ -45,12 +45,9 @@ To set your log folder path, simply set this folder variable named 'LOG_PATH' li
 
 .. code-block::
 
-    export LOG_PATH="yourLogPath"
+    export LOG_PATH="/your/custom/log/path"
 
 
-
-
-The code above is the command line expression for setting this environment variable on Mac OSX. Other operating systems might have a slightly different techniques for setting environment variables on the command line.
 
 2. Using the configuration file.
 ###################################################################
@@ -130,7 +127,25 @@ You may want to listen messages asynchronously like so:
 Log Files
 _________
 
-Very minimal logging is written to the module's path 'logs/dj-dna-streaming-python.log'. To keep maintenance simple this log is overwritten every time the app starts.
+
+Minimal logging is written to a file named `dj-dna-streaming-python.log`.
+
+By default, logs are written to the first available directory from the following list:
+
+1. A custom path set via the environment variable `LOG_PATH`.
+2. A `logs/` folder located within the package installation directory.
+3. A fallback directory: `~/.dj-dna-streaming-python/logs/`.
+
+The first writable location found is selected. A message like `Will log to: /your/custom/log/path` is printed to the console on startup.
+
+💡 The log file is overwritten each time the application starts to keep maintenance simple.
+
+You can specify:
+
+- **Absolute paths**: For example, `/var/log/dna-streaming`.
+- **Relative paths**: For example, `./logs`, relative to the current working directory at runtime.
+
+The code verifies that the specified path is writable. If it isn’t, it automatically falls back to the next available option.
 
 
 Testing

--- a/dnaStreaming/__init__.py
+++ b/dnaStreaming/__init__.py
@@ -4,6 +4,7 @@ import os
 import sys
 import logging
 
+
 def get_log_path():
     env_log_path = os.getenv("LOG_PATH")
     fallback_log_dir = os.path.expanduser('~/.dj-dna-streaming-python/logs')
@@ -25,6 +26,7 @@ def get_log_path():
                 print(f"WARNING: Cannot write to '{path}': {e}")
 
     raise RuntimeError("ERROR: Could not find a writable log directory.")
+
 
 log_path = get_log_path()
 print("Will log to: {}".format(log_path))

--- a/dnaStreaming/__init__.py
+++ b/dnaStreaming/__init__.py
@@ -5,7 +5,7 @@ import sys
 import logging
 
 def get_log_path():
-    env_log_path = os.getenv("DJ_DNA_LOG_PATH")
+    env_log_path = os.getenv("LOG_PATH")
     fallback_log_dir = os.path.expanduser('~/.dj-dna-streaming-python/logs')
     base_dir = os.path.dirname(__file__)
     default_path = os.path.join(base_dir, 'logs')

--- a/dnaStreaming/__init__.py
+++ b/dnaStreaming/__init__.py
@@ -4,22 +4,36 @@ import os
 import sys
 import logging
 
+def get_log_path():
+    env_log_path = os.getenv("DJ_DNA_LOG_PATH")
+    fallback_log_dir = os.path.expanduser('~/.dj-dna-streaming-python/logs')
+    base_dir = os.path.dirname(__file__)
+    default_path = os.path.join(base_dir, 'logs')
 
-BASE_DIR = os.path.dirname(__file__)
+    candidates = [env_log_path, default_path, fallback_log_dir]
 
-logging.basicConfig(level=logging.WARN)
+    for path in candidates:
+        if path:
+            try:
+                os.makedirs(path, exist_ok=True)
+                testfile = os.path.join(path, '.write_test')
+                with open(testfile, 'w') as f:
+                    f.write('test')
+                os.remove(testfile)
+                return path
+            except Exception as e:
+                print(f"WARNING: Cannot write to '{path}': {e}")
 
-logger = logging.getLogger()
+    raise RuntimeError("ERROR: Could not find a writable log directory.")
 
-log_path = os.path.join(BASE_DIR, 'logs')
-
+log_path = get_log_path()
 print("Will log to: {}".format(log_path))
 
-if not os.path.exists(log_path):
-    os.mkdir(log_path)
+# Logging setup
+logging.basicConfig(level=logging.WARN)
+logger = logging.getLogger()
 
-fileHandler = logging.FileHandler("{0}/{1}.log".format(log_path, 'dj-dna-streaming-python'))
-
+fileHandler = logging.FileHandler(os.path.join(log_path, 'dj-dna-streaming-python.log'))
 logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
 fileHandler.setFormatter(logFormatter)
 logger.addHandler(fileHandler)


### PR DESCRIPTION
It allows you to define your desired log path. Otherwise, it will choose others by default.

How to test:
- Set the following environment variable, if you want:
  - LOG_PATH={the path which will contain the logs)}
 