### PR TITLE
Require setuptools >= 75.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     include_package_data=True,
 
     install_requires=[
+        'setuptools>=75.1.0',
         'googleapis-common-protos>=1.56.4',
         'google-auth>=2.11.0',
         'google-cloud-pubsub==2.13.6',


### PR DESCRIPTION
Adds a minimum version requirement for the setuptools package to ensure compatibility and access to necessary features or fixes.